### PR TITLE
Fix garbled characters in a experiment

### DIFF
--- a/code/PowerShell/ExperimentCmdlets.cs
+++ b/code/PowerShell/ExperimentCmdlets.cs
@@ -202,7 +202,7 @@ namespace AzureML.PowerShell
             if (Overwrite.IsPresent && !string.IsNullOrEmpty(NewName))
                 WriteWarning("Since you specified Overwrite, the new name supplied will be igored.");
             string rawJson = File.ReadAllText(InputFile);
-            MemoryStream ms = new MemoryStream(UnicodeEncoding.Unicode.GetBytes(rawJson));
+            MemoryStream ms = new MemoryStream(UnicodeEncoding.UTF8.GetBytes(rawJson));
             ser = new DataContractJsonSerializer(typeof(Experiment));
             Experiment exp = (Experiment)ser.ReadObject(ms);
             if (Overwrite)
@@ -437,7 +437,7 @@ namespace AzureML.PowerShell
             string rawJson = string.Empty;
             Experiment exp = Sdk.GetExperimentById(GetWorkspaceSetting(), ExperimentId, out rawJson);
             rawJson = Sdk.AutoLayoutGraph(rawJson);
-            MemoryStream ms = new MemoryStream(UnicodeEncoding.Unicode.GetBytes(rawJson));
+            MemoryStream ms = new MemoryStream(UnicodeEncoding.UTF8.GetBytes(rawJson));
             ser = new DataContractJsonSerializer(typeof(Experiment));
             exp = (Experiment)ser.ReadObject(ms);
             Sdk.SaveExperiment(GetWorkspaceSetting(), exp, rawJson);

--- a/code/Util.cs
+++ b/code/Util.cs
@@ -39,7 +39,7 @@ namespace AzureML
             if (jsonBody == null)
                 jsonBody = string.Empty;
             HttpClient hc = GetAuthenticatedHttpClient();
-            StringContent sc = new StringContent(jsonBody, Encoding.ASCII, "application/json");
+            StringContent sc = new StringContent(jsonBody, Encoding.UTF8, "application/json");
             HttpResponseMessage resp = await hc.PostAsync(url, sc);
             HttpResult hr = await CreateHttpResult(resp);
             return hr;


### PR DESCRIPTION
If your comments in an experiment have no-ASCII characters (Japanese, Chinese, and so on), they got garbled when you import a JSON file with Import-AmlExperimentGraph.

Observed: 
![image](https://user-images.githubusercontent.com/36452658/36172594-390a2a78-10bb-11e8-90cd-b375b8f549c5.png)

Expected: 
![image](https://user-images.githubusercontent.com/36452658/36172642-5f11db30-10bb-11e8-9495-b06995823117.png)

The Unicode encoding and ASCII encoding is used while the UTF-8 is expected. I changed these encoding to UTF-8.